### PR TITLE
Add rolling file appender logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/target
-/signal_server/target
+target/
+logs/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,6 +2292,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "uuid",
  "warp",
@@ -2608,6 +2609,17 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
+dependencies = [
+ "crossbeam-channel",
+ "time 0.3.13",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/signal_server/Cargo.toml
+++ b/signal_server/Cargo.toml
@@ -16,6 +16,7 @@ nokhwa = "0.9.4"
 anyhow = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "registry", "local-time", "env-filter"]}
+tracing-appender = "0.2"
 chrono = "0.4"
 
 [dependencies.uuid]

--- a/signal_server/src/log.rs
+++ b/signal_server/src/log.rs
@@ -1,28 +1,29 @@
-use tracing::Subscriber;
-use tracing_subscriber::prelude::*;
-use tracing_subscriber::Layer;
-use tracing_subscriber::{fmt, EnvFilter};
-
-pub struct StdoutLogger;
-
-impl<S: Subscriber> Layer<S> for StdoutLogger {}
+use tracing_subscriber::{prelude::*, fmt, EnvFilter};
+use tracing_appender::rolling::{RollingFileAppender, Rotation};
 
 pub fn start_logger() {
-    // tracing::subscriber::set_global_default(file_logger)
-    //   .expect("setting file_logger failed");
-    let fmt_layer = fmt::layer()
+
+    let stdout_logger = fmt::layer()
         .with_target(false)
         .with_line_number(true)
         .with_file(true);
 
-    let filter_layer = EnvFilter::try_from_default_env()
+    let stdout_filter = EnvFilter::try_from_default_env()
         .or_else(|_| EnvFilter::try_new("debug"))
         .unwrap();
 
-    let stdout_logger = StdoutLogger;
+    let file_appender = RollingFileAppender::new(Rotation::DAILY, "logs", "signal_server.log");
+    let debug_log = tracing_subscriber::fmt::layer()
+        .with_target(true)
+        .with_line_number(true)
+        .with_file(true)
+        .with_writer(file_appender);
+
     tracing_subscriber::registry()
-        .with(filter_layer)
-        .with(fmt_layer)
-        .with(stdout_logger)
+        .with(
+            stdout_logger
+                .with_filter(stdout_filter)
+                .and_then(debug_log)
+        )
         .init();
 }

--- a/signal_server/src/log.rs
+++ b/signal_server/src/log.rs
@@ -1,28 +1,32 @@
-use tracing_subscriber::{prelude::*, fmt, EnvFilter};
+use tracing_subscriber::{prelude::*, fmt, filter};
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 
 pub fn start_logger() {
+    let stdout_filter = filter::FilterFn::new(|metadata| {
+        metadata.target() == "signal_server"
+    });
+    let file_filter = filter::FilterFn::new(|metadata| {
+        metadata.target() == "signal_server"
+    });
 
     let stdout_logger = fmt::layer()
         .with_target(false)
         .with_line_number(true)
-        .with_file(true);
+        .with_file(true)
+        .with_filter(stdout_filter);
 
-    let stdout_filter = EnvFilter::try_from_default_env()
-        .or_else(|_| EnvFilter::try_new("debug"))
-        .unwrap();
-
+    
     let file_appender = RollingFileAppender::new(Rotation::DAILY, "logs", "signal_server.log");
     let debug_log = tracing_subscriber::fmt::layer()
         .with_target(true)
         .with_line_number(true)
         .with_file(true)
-        .with_writer(file_appender);
+        .with_writer(file_appender)
+        .with_filter(file_filter);
 
     tracing_subscriber::registry()
         .with(
             stdout_logger
-                .with_filter(stdout_filter)
                 .and_then(debug_log)
         )
         .init();


### PR DESCRIPTION
Use the tracing-appender crate in order to record logs in a rolling daily file. For now it just outputs always the DEBUG records to the file. In the future we can add some non-blocking logging (including the stdout).